### PR TITLE
fix(probes): Change probes to the right path

### DIFF
--- a/charts/newrelic-exporter/templates/nr-exporter-deployment.yaml
+++ b/charts/newrelic-exporter/templates/nr-exporter-deployment.yaml
@@ -59,11 +59,11 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.service.port }}
-              path: /metrics
+              path: /health
           livenessProbe:
             httpGet:
               port: {{ .Values.service.port }}
-              path: /metrics
+              path: /health
           volumeMounts:
             - name: config
               mountPath: /app/newrelic_exporter.yml


### PR DESCRIPTION
Changing probes to `/health` path, since it's more performatic than `/metrics`, which sometimes take more than 1 second to respond with all the metrics, but it doesn't mean that the application needs to be restarted from k8s.